### PR TITLE
Use default system path

### DIFF
--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -20,7 +20,7 @@ define ruby::version(
   $priority = '10'
 ) {
   # set a default PATH for all execs
-  Exec { path => '/usr/local/bin:/bin' }
+  Exec { path => $::path }
 
   exec { "build_ruby_${version_name}":
     command => "ruby-build ${version_name} /usr/local/ruby-${version_name}",


### PR DESCRIPTION
The path attribute of the Exec resource is too tight to find some
required tools on centos6 (e.g. 'test' is in /usr/bin, 'alternatives' is
in '/usr/sbin'). Therefore we set the path to the standard system path
which should enable required tools to be found.